### PR TITLE
Fix #2 raw_count is non-numeric in get_table_link_lookup when data size > 32,000

### DIFF
--- a/R/get_table_link_lookup.R
+++ b/R/get_table_link_lookup.R
@@ -71,7 +71,7 @@ get_table_link_lookup <- function(lookup_table, col_name_1, col_name_2, col_name
       }
       loop_num <- loop_num + 1
     }
-  } else if ((raw_count <= 32000) & (raw_count > 0)) {
+  } else if ((raw_count$count <= 32000) & (raw_count$count > 0)) {
     #If the dataset has fewer than 32,000 rows, can just do the simple extraction
     if ((col_name_1 == col_name_2) & (col_name_3 == col_name_4)) {
       api_link_full <- paste0(api_link,queries,col_name_1,",",col_name_3,"&returnGeometry=false&resultType=standard&outSR=4326&f=json")
@@ -92,9 +92,9 @@ get_table_link_lookup <- function(lookup_table, col_name_1, col_name_2, col_name
 					     con_code_large = raw_data[["features"]][[j]][["attributes"]][[col_name_3]],
 					     con_code_small = raw_data[["features"]][[j]][["attributes"]][[col_name_4]]))
     }
-  } else if (raw_count > 32000) {
+  } else if (raw_count$count > 32000) {
     #if the dataset is large and the API count is successful, loop through the dataset in 32,000 row extracts until all of the data has been extracted
-    num_loops = ceiling(raw_count / 32000)
+    num_loops = ceiling(raw_count$count / 32000)
     for (n in 1:num_loops) {
       off_set_val <- (n - 1) * 32000
       if ((col_name_1 == col_name_2) & (col_name_3 == col_name_4)) {

--- a/R/get_table_link_lookup.R
+++ b/R/get_table_link_lookup.R
@@ -22,123 +22,100 @@
 #' @returns A tidy dataframe, providing a lookup between two chosen boundary resolutions.
 #' @export
 
-get_table_link_lookup <- function(lookup_table,col_name_1,col_name_2,col_name_3,col_name_4){
+get_table_link_lookup <- function(lookup_table, col_name_1, col_name_2, col_name_3, col_name_4) {
   
-  assert_function(grepl("\\s",lookup_table),"Boundary must be not contain any spaces, see https://geoportal.statistics.gov.uk/search?q=Boundary&sort=Date%20Created%7Ccreated%7Cdesc for available boundaries")
-  api_link <- paste0("https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/",lookup_table,"/FeatureServer/0/")
+  assert_function(grepl("\\s", lookup_table),"Boundary must be not contain any spaces, see https://geoportal.statistics.gov.uk/search?q=Boundary&sort=Date%20Created%7Ccreated%7Cdesc for available boundaries")
+  api_link <- paste0("https://services1.arcgis.com/ESMARspQHYMw9BZ9/arcgis/rest/services/", lookup_table, "/FeatureServer/0/")
   queries <- "query?where=1%3D1&outFields="
 
   #Check whether the two scales are the same- this is the case for single constituency lookups
-  if ((col_name_1 == col_name_2) & (col_name_3 == col_name_4)){
-    api_link_count <- paste0(api_link,queries,col_name_1,",",col_name_3,"&returnGeometry=false&resultType=standard&returnCountOnly=true&outSR=4326&f=json")
-  }
-  else{
-  api_link_count <- paste0(api_link,queries,col_name_1,",",col_name_2,",",col_name_3,",",col_name_4,"&returnGeometry=false&resultType=standard&returnCountOnly=true&outSR=4326&f=json")
+  if ((col_name_1 == col_name_2) & (col_name_3 == col_name_4)) {
+    api_link_count <- paste0(api_link, queries, col_name_1, ",", col_name_3, "&returnGeometry=false&resultType=standard&returnCountOnly=true&outSR=4326&f=json")
+  } else {
+    api_link_count <- paste0(api_link, queries, col_name_1, ",", col_name_2, ",", col_name_3, ",", col_name_4, "&returnGeometry=false&resultType=standard&returnCountOnly=true&outSR=4326&f=json")
   }
   
   #Find the number of rows in the dataset of interes
-  x_c <- httr::GET(paste0(
-    api_link_count))
+  x_c <- httr::GET(paste0(api_link_count))
   raw_count <- httr::content(x_c)
-
-
+  
   #The restful/esri API has a limit of 32,000 rows that it will return.
   #If the table is larger than this you must loop through the API mul;tiple times to extract all of the data
   available_datasets <- data.frame()
   # (re-)setting loop parameters to 0
   loop_bool = "True" 
-  loop_num=0
+  loop_num = 0
   #Some tables do not produce a response to the counting process above, must use a more rudimentary process for these tables
-  if (raw_count$count ==0){
-    while (loop_bool == "True"){
-      off_set_val = loop_num*32000
-    if ((col_name_1 == col_name_2) & (col_name_3 == col_name_4)){
-      api_link_full <- paste0(api_link,queries,col_name_1,",",col_name_3,"&returnGeometry=false&resultType=standard&resultOffset=",off_set_val,"&outSR=4326&f=json")
-    }
-    else{
+  if (raw_count$count == 0) {
+    while (loop_bool == "True") {
+      off_set_val = loop_num * 32000
+      if ((col_name_1 == col_name_2) & (col_name_3 == col_name_4)) {
+        api_link_full <- paste0(api_link,queries,col_name_1,",",col_name_3,"&returnGeometry=false&resultType=standard&resultOffset=",off_set_val,"&outSR=4326&f=json")
+      } else {
       api_link_full <- paste0(api_link,queries,col_name_1,",",col_name_2,",",col_name_3,",",col_name_4,"&returnGeometry=false&resultType=standard&resultOffset=",off_set_val,"&outSR=4326&f=json")
-    }
-    
-
-    x <- httr::GET(paste0(
-      api_link_full))
-    raw_data <- httr::content(x)
-    raw_count <- length(raw_data$features)
-    if (raw_count == 0){loop_bool <- "False"}
-    
-    if (raw_count > 0){
-    for(j in 1:length(raw_data$features)){
+      }
       
+      x <- httr::GET(paste0(api_link_full))
+      raw_data <- httr::content(x)
+      raw_count <- length(raw_data$features)
+      if (raw_count == 0) { loop_bool <- "False" }
       
-      available_datasets <- rbind(available_datasets,
-                                 data.frame(
-                                   con_name_large = raw_data[["features"]][[j]][["attributes"]][[col_name_1]],
-                                   con_name_small = raw_data[["features"]][[j]][["attributes"]][[col_name_2]],
-                                   con_code_large = raw_data[["features"]][[j]][["attributes"]][[col_name_3]],
-                                   con_code_small = raw_data[["features"]][[j]][["attributes"]][[col_name_4]]
-                                 )
-                                 
-      )
-    }}
-    loop_num <- loop_num+1
+      if (raw_count > 0) {
+        for(j in 1:length(raw_data$features)) {      
+          available_datasets <- rbind(available_datasets, 
+				      data.frame(con_name_large = raw_data[["features"]][[j]][["attributes"]][[col_name_1]], 
+						 con_name_small = raw_data[["features"]][[j]][["attributes"]][[col_name_2]],
+						 con_code_large = raw_data[["features"]][[j]][["attributes"]][[col_name_3]],
+						 con_code_small = raw_data[["features"]][[j]][["attributes"]][[col_name_4]]))
+        }
+      }
+      loop_num <- loop_num + 1
     }
-  }
-  #If the dataset has fewer than 32,000 rows, can just do the simple extraction
-  else if ((raw_count <= 32000) & (raw_count > 0)){
-    if ((col_name_1 == col_name_2) & (col_name_3 == col_name_4)){
+  } else if ((raw_count <= 32000) & (raw_count > 0)) {
+    #If the dataset has fewer than 32,000 rows, can just do the simple extraction
+    if ((col_name_1 == col_name_2) & (col_name_3 == col_name_4)) {
       api_link_full <- paste0(api_link,queries,col_name_1,",",col_name_3,"&returnGeometry=false&resultType=standard&outSR=4326&f=json")
-    }
-    else{
+    } else{
       api_link_full <- paste0(api_link,queries,col_name_1,",",col_name_2,",",col_name_3,",",col_name_4,"&returnGeometry=false&resultType=standard&outSR=4326&f=json")
     }
+    
     #extract the data using the API
-    x <- httr::GET(paste0(
-      api_link_full))
+    x <- httr::GET(paste0(api_link_full))
     raw_data <- httr::content(x)
+
     #Generate a table showing the large constituency names and codes, and the corresponding small constituency names contained within the larger constituency
     #e.g. The large constituency may be the "North East" region, and the small constituencies would be all of the LSOAs within the North East region
-  for(j in 1:length(raw_data$features)){
-    
-
-    available_datasets <- rbind(available_datasets,
-                               data.frame(
-                                 con_name_large = raw_data[["features"]][[j]][["attributes"]][[col_name_1]],
-                                 con_name_small = raw_data[["features"]][[j]][["attributes"]][[col_name_2]], # No longer needed - removed to save space
-                                 con_code_large = raw_data[["features"]][[j]][["attributes"]][[col_name_3]],
-                                 con_code_small = raw_data[["features"]][[j]][["attributes"]][[col_name_4]]
-                               )
-    )
-  }}
-  #if the dataset is large and the API count is successful, loop through the dataset in 32,000 row extracts until all of the data has been extracted
-  else if (raw_count > 32000){
-    num_loops = ceiling(raw_count/32000)
-    for (n in 1:num_loops){
-    off_set_val <- (n-1)*32000
-    if ((col_name_1 == col_name_2) & (col_name_3 == col_name_4)){
-      api_link_full <- paste0(api_link,queries,col_name_1,",",col_name_3,"&returnGeometry=false&resultType=standard&resultOffset=",off_set_val,"&outSR=4326&f=json")
+    for(j in 1:length(raw_data$features)) {
+      available_datasets <- rbind(available_datasets, 
+				  data.frame(con_name_large = raw_data[["features"]][[j]][["attributes"]][[col_name_1]],
+					     con_name_small = raw_data[["features"]][[j]][["attributes"]][[col_name_2]], # No longer needed - removed to save space
+					     con_code_large = raw_data[["features"]][[j]][["attributes"]][[col_name_3]],
+					     con_code_small = raw_data[["features"]][[j]][["attributes"]][[col_name_4]]))
     }
-    else{
-      api_link_full <- paste0(api_link,queries,col_name_1,",",col_name_2,",",col_name_3,",",col_name_4,"&returnGeometry=false&resultType=standard&resultOffset=",off_set_val,"&outSR=4326&f=json")
-    }
-    
-    rm(x)
-    rm(raw_data)
-    x <- httr::GET(paste0(
-      api_link_full))
-    raw_data <- httr::content(x)
-    
-    for(j in 1:length(raw_data$features)){
+  } else if (raw_count > 32000) {
+    #if the dataset is large and the API count is successful, loop through the dataset in 32,000 row extracts until all of the data has been extracted
+    num_loops = ceiling(raw_count / 32000)
+    for (n in 1:num_loops) {
+      off_set_val <- (n - 1) * 32000
+      if ((col_name_1 == col_name_2) & (col_name_3 == col_name_4)) {
+        api_link_full <- paste0(api_link, queries, col_name_1, ",", col_name_3, "&returnGeometry=false&resultType=standard&resultOffset=", off_set_val, "&outSR=4326&f=json")
+      } else{
+        api_link_full <- paste0(api_link, queries, col_name_1, ",", col_name_2, ",", col_name_3, ",", col_name_4, "&returnGeometry=false&resultType=standard&resultOffset=", off_set_val, "&outSR=4326&f=json")
+      }
       
-
-      available_datasets <- rbind(available_datasets,
-                                 data.frame(
-                                   con_name_large = raw_data[["features"]][[j]][["attributes"]][[col_name_1]],
-                                   con_name_small = raw_data[["features"]][[j]][["attributes"]][[col_name_2]],
-                                   con_code_large = raw_data[["features"]][[j]][["attributes"]][[col_name_3]],
-                                   con_code_small = raw_data[["features"]][[j]][["attributes"]][[col_name_4]]
-                                 )
-      )
-    }}
+      rm(x)
+      rm(raw_data)
+      x <- httr::GET(paste0(api_link_full))
+      raw_data <- httr::content(x)
+      
+      for(j in 1:length(raw_data$features)) {
+        available_datasets <- rbind(available_datasets,
+				    data.frame(con_name_large = raw_data[["features"]][[j]][["attributes"]][[col_name_1]],
+					       con_name_small = raw_data[["features"]][[j]][["attributes"]][[col_name_2]],
+					       con_code_large = raw_data[["features"]][[j]][["attributes"]][[col_name_3]],
+					       con_code_small = raw_data[["features"]][[j]][["attributes"]][[col_name_4]]))
+      }
+    }
   }
   #remove duplicates
   available_datasetsfin <- available_datasets %>% distinct()

--- a/tests/testthat/test-get_table_link_lookup.R
+++ b/tests/testthat/test-get_table_link_lookup.R
@@ -1,0 +1,1 @@
+test_that("Test raw_count > 32000 example", { expect_no_error(get_table_link_lookup('LSOA_DEC_2021_EW_NC_v3', 'LSOA21NM', 'LSOA21NM', 'LSOA21CD', 'LSOA21CD')) })


### PR DESCRIPTION
If the table retrieved when calling get_table_link_lookup is greater than 32,000 then the following error is produced:

`Error in raw_count/32000 : non-numeric argument to binary operator`

see #2 

**Commits**
- Add a test case reproducing the error 9811720
- Make some improvements to readability ffa544c
- Fix the issue such that test case passes aefaf58

![image](https://github.com/user-attachments/assets/44444b69-9101-4a05-91a8-b892cb28ca5f)